### PR TITLE
expand and align the nav list in small screen devices

### DIFF
--- a/source/css/hiero.css
+++ b/source/css/hiero.css
@@ -419,6 +419,7 @@ object {
 @media only screen and (max-width: 60em) {
 	.nav-open {
 		display: block;
+		cursor: pointer;
 		text-align: center;
 		}
 	#main-navigation:target > .nav-open {
@@ -438,7 +439,7 @@ object {
 		left: 0;
 		width: 100%;
 		max-height: 0;
-		max-width: 16em;
+		text-align: center;
 		overflow: hidden;
 		background: #333;
 		z-index: 1;


### PR DESCRIPTION
## What it is?
Small style modification of the nav bar

## Why?
It previously looked like this:
![lnfi_t27zru1v1m q1 w4n](https://user-images.githubusercontent.com/13282699/28562586-6f487aa0-7155-11e7-931d-7f21764507dc.png)

which is super ugly, because the `li` is meant to be the same width as the nav bar itself. Besides, it doesn't have any alignment.

Now it should look like this:
![pdaqp__ _iojbs o246_73m](https://user-images.githubusercontent.com/13282699/28562614-918ac992-7155-11e7-8931-92e94346509e.png)

And it looks good on small screens as well:
![q_1z b75 cv6 r2fmxaezx](https://user-images.githubusercontent.com/13282699/28562629-9bbfa8ec-7155-11e7-848e-6ae61f2a8bf2.png)
