### PR TITLE
添加对Gitment评论系统的支持

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -88,10 +88,10 @@ livere_shortname: ~
 uyan_uid: 
 wumii:
 gitment:
-    owner:                   #Your GitHub ID
-    repo:                    #The repo to store comments
-    client_id:               #Your client ID
-    client_secret:           #Your client secret
+  owner:                   #Your GitHub ID
+  repo:                    #The repo to store comments
+  client_id:               #Your client ID
+  client_secret:           #Your client secret
 
 # Code Highlight theme
 # Available value:

--- a/_config.yml
+++ b/_config.yml
@@ -75,7 +75,7 @@ social:
 
 # Search
 search:
-    insight: true # you need to install `hexo-generator-json-content` before using Insight Search
+    insight: false # you need to install `hexo-generator-json-content` before using Insight Search
     swiftype: # enter swiftype install key here
     baidu: false # you need to disable other search engines to use Baidu search, options: true, false
 
@@ -84,9 +84,14 @@ search:
 gentie_productKey: #your-gentie-product-key
 duoshuo_shortname:
 disqus_shortname: 
-livere_shortname: MTAyMC8yOTQ4MS82MDQ5
+livere_shortname: ~
 uyan_uid: 
-wumii: 
+wumii:
+gitment:
+    owner:                   #Your GitHub ID
+    repo:                    #The repo to store comments
+    client_id:               #Your client ID
+    client_secret:           #Your client secret
 
 # Code Highlight theme
 # Available value:

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -47,8 +47,8 @@
       <% if (!index && theme.donate.enable){ %>
         <%- partial('donate') %>
       <% } %>
-
-      <% if (!index && post.comments && (theme.gentie_productKey || theme.duoshuo_shortname || theme.disqus_shortname || theme.uyan_uid || theme.wumii || theme.livere_shortname)){ %>
+            
+      <% if (!index && post.comments && (theme.gentie_productKey || theme.duoshuo_shortname || theme.disqus_shortname || theme.uyan_uid || theme.wumii || theme.livere_shortname || theme.gitment.owner)){ %>
         <%- partial('comment') %>
       <% } %>
     </footer>

--- a/layout/_partial/comment.ejs
+++ b/layout/_partial/comment.ejs
@@ -104,4 +104,22 @@
 		</div>
 		<!-- City版安装代码已完成 -->
 	</div>
+<% } eles if (theme.gitment.owner && theme.gitment.repo && theme.gitment.client_id && theme.gitment.client_secret) {%>
+	<div id="comments"></div>
+	<link rel="stylesheet" href="https://imsun.github.io/gitment/style/default.css">
+	<script src="https://imsun.github.io/gitment/dist/gitment.browser.js"></script>
+	<script>
+	var gitment = new Gitment({
+		id: '<%- post.permalink %>',
+		owner: '<%- theme.gitment.owner %>',
+		repo: '<%- theme.gitment.repo %>',
+		oauth: {
+			client_id: '<%- theme.gitment.client_id %>',
+			client_secret: '<%- theme.gitment.client_secret %>',
+		},
+	})
+	gitment.render('comments')
+	</script>
+
+
 <% } %>

--- a/layout/_partial/comment.ejs
+++ b/layout/_partial/comment.ejs
@@ -104,7 +104,8 @@
 		</div>
 		<!-- City版安装代码已完成 -->
 	</div>
-<% } eles if (theme.gitment.owner && theme.gitment.repo && theme.gitment.client_id && theme.gitment.client_secret) {%>
+<% } else if (theme.gitment.client_secret) {%>
+  <!-- Gitment START! Deploy by Z4HD -->
 	<div id="comments"></div>
 	<link rel="stylesheet" href="https://imsun.github.io/gitment/style/default.css">
 	<script src="https://imsun.github.io/gitment/dist/gitment.browser.js"></script>
@@ -120,6 +121,5 @@
 	})
 	gitment.render('comments')
 	</script>
-
-
+	<!-- Gitment END! -->
 <% } %>

--- a/layout/_partial/comment.ejs
+++ b/layout/_partial/comment.ejs
@@ -33,7 +33,7 @@
 	<!-- 多说公共JS代码 end -->
 	
 	</div>
-	<%- css('css/comment.css') %>
+	<%- css('css/comment-ds.css') %>
 <% } else if (theme.disqus_shortname) {%>
 	<section id="comments" class="comment">
 	  <div id="disqus_thread">
@@ -121,5 +121,7 @@
 	})
 	gitment.render('comments')
 	</script>
+	<!-- Gitment 自定义样式表 -->
+	<%- css('css/comment-gitment.css') %>
 	<!-- Gitment END! -->
 <% } %>

--- a/source/css/comment-ds.css
+++ b/source/css/comment-ds.css
@@ -82,3 +82,12 @@ padding: 0 3px;
 
 #ds-thread #ds-reset .ds-post-button {background: #16171b;}
 #ds-thread #ds-reset .ds-post-button:hover {background: #ff2828;}
+
+/*Gitment TAB 颜色调整*/
+.gitment-editor-tab{
+    transition: color 1s;
+    -moz-transition: color 1s;	/* Firefox 4 */
+    -webkit-transition: color 1s;	/* Safari 和 Chrome */
+    -o-transition: color 1s;
+}
+.gitment-editor-tab:hover{color: white}

--- a/source/css/comment-ds.css
+++ b/source/css/comment-ds.css
@@ -82,12 +82,3 @@ padding: 0 3px;
 
 #ds-thread #ds-reset .ds-post-button {background: #16171b;}
 #ds-thread #ds-reset .ds-post-button:hover {background: #ff2828;}
-
-/*Gitment TAB 颜色调整*/
-.gitment-editor-tab{
-    transition: color 1s;
-    -moz-transition: color 1s;	/* Firefox 4 */
-    -webkit-transition: color 1s;	/* Safari 和 Chrome */
-    -o-transition: color 1s;
-}
-.gitment-editor-tab:hover{color: white}

--- a/source/css/comment-gitment.css
+++ b/source/css/comment-gitment.css
@@ -1,0 +1,18 @@
+/*Gitment TAB 颜色调整*/
+.gitment-editor-tab{
+    transition: color 0.25s, background 0.25s, border-color 0.25s;
+    -moz-transition: color 0.25s, background 0.25s, border-color 0.25s;	/* Firefox 4 */
+    -webkit-transition: color 0.25s, background 0.25s, border-color 0.25s;	/* Safari 和 Chrome */
+    -o-transition: color 0.25s, background 0.25s, border-color 0.25s;
+}
+.gitment-editor-tab:hover{
+    color: white;
+    background: black;
+    border-color: black;
+}
+.gitment-selected:hover{
+    color: inherit !important;
+    background: inherit !important;
+    border-color: #CFD8DC !important;
+}
+.gitment-editor-submit{background-color: #ff321e !important}

--- a/source/css/comment-gitment.css
+++ b/source/css/comment-gitment.css
@@ -10,9 +10,4 @@
     background: black;
     border-color: black;
 }
-.gitment-selected:hover{
-    color: inherit !important;
-    background: inherit !important;
-    border-color: #CFD8DC !important;
-}
 .gitment-editor-submit{background-color: #ff321e !important}


### PR DESCRIPTION
>[Gitment](https://github.com/imsun/gitment)是一款基于 GitHub Issues 的评论系统。支持在前端直接引入，不需要任何后端代码。可以在页面进行登录、查看、评论、点赞等操作，同时有完整的 Markdown / GFM 和代码高亮支持。尤为适合各种基于 GitHub Pages 的静态博客或项目页面。

****

### **Gitment原生支持HTTPS** 
<s>(不然我用友言就好了干嘛折腾Gitment)</s>

****
主题配置文件中新增下列设置项：

``` yaml
gitment:
  owner:                     #Your GitHub ID  (你的 GitHub ID)
  repo:                        #The repo to store comments  (存储评论的 repo，请确保您是该repo的owner)
  client_id:                  #Your client ID (你的 client ID)
  client_secret:           #Your client secret (你的 client secret)
```

[注册 OAuth Application](https://github.com/settings/applications/new) 后将相应的内容填入配置文件中即可。

### 已知问题
1. 目前对于是否展示gitment组件的判断逻辑存在缺陷，但勉强可以使用。<s>（主要是不容易出错）</s>
1. 或许我自己魔改的样式并不美观，求其他神触帮忙修改，3Q2X。