### PR TITLE
修改关于页面大图显示的判断逻辑

### DIFF
--- a/layout/_partial/header-post.ejs
+++ b/layout/_partial/header-post.ejs
@@ -34,8 +34,8 @@
   </div>
 </header>
 
-<% if (is_current("about", false) && theme.about_big_image){ %>
-  <div style="background: #fff; width: 100%;">
+<% if (theme.about_big_image){ %>
+  <div id="originBgDiv" style="background: #fff; width: 100%;">
 
       <div style="max-height:600px; overflow: hidden;  display: flex; display: -webkit-flex; align-items: center;">
         <img id="originBg" width="100%" alt="" src="">
@@ -44,6 +44,7 @@
   </div>
 
   <script>
+  function setAboutIMG(){
       var imgUrls = "<%- theme.about_big_image %>".split(",");
       var random = Math.floor((Math.random() * imgUrls.length ));
       if (imgUrls[random].startsWith('http') || imgUrls[random].indexOf('://') >= 0) {
@@ -51,5 +52,13 @@
       } else {
         document.getElementById("originBg").src='<%= config.root %>' + imgUrls[random];
       }
+  }
+  bgDiv=document.getElementById("originBgDiv");
+  if(location.pathname.match('about')){
+    setAboutIMG();
+    bgDiv.style.display='block';
+  }else{
+    bgDiv.style.display='none';
+  }
   </script>
 <% } %>


### PR DESCRIPTION
考虑到#34 中出现的迷之问题，将原本在Hexo进行的判断转移至前端进行判断。通过判断`location.pathname`中是否存在`"about"`字符串来辨别该页面是否为关于页面。如为是，则展示关于页面图片，否则设置最外层div的`display`属性为`none`。

效果可以参考我的博客：https://blog.z4hd.cf

***

Fix #34 #12 中有关于关于页面图片显示不正常的问题