### PR TITLE
New feature to replace the TOC with the sidebar like in homepage and updated posted_on according to language

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,9 @@ random_thumb: false
 post_catalog:
   enable: true
 
+# Sidebar like in homepage, is necessary to disable [post_catalog]
+post_sidebar:
+  enable: false
 
 # Content
 fancybox: true

--- a/languages/default.yml
+++ b/languages/default.yml
@@ -25,6 +25,7 @@ post_total_count: There are %d posts in total till now.
 read_more: Continue Reading →
 contents: Contents
 none: None
+posted_on: Posted on
 donation:
     button_text: 'Donate'
 insight:

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -25,6 +25,7 @@ post_total_count: There are %d posts in total till now.
 read_more: Continue Reading →
 contents: Contents
 none: None
+posted_on: Posted on
 donation:
     button_text: 'Donate'
 insight:

--- a/languages/es.yml
+++ b/languages/es.yml
@@ -25,6 +25,7 @@ post_total_count: Hay %d publicaciones en total hasta ahora.
 read_more: Continuar leyendo →
 contents: Contenido
 none: Ninguno
+posted_on: Publicado en
 donation:
     button_text: 'Donar'
 insight:

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -1,4 +1,4 @@
-<article id="<%= post.layout %>-<%= post.slug %>" <% if (!index && is_post() && theme.post_catalog.enable){ %>style="width: 66%; float:left;"<% } %> class="article article-type-<%= post.layout %>" itemscope itemprop="blogPost" >
+<article id="<%= post.layout %>-<%= post.slug %>" <% if (!index && is_post() && ( theme.post_catalog.enable || theme.post_sidebar.enable )){ %>style="width: 66%; float:left;"<% } %> class="article article-type-<%= post.layout %>" itemscope itemprop="blogPost" >
   <div id="articleInner" class="clearfix post-1016 post type-post status-publish format-standard has-post-thumbnail hentry category-template-2 category-uncategorized tag-codex tag-edge-case tag-featured-image tag-image tag-template">
     <%- partial('post/gallery') %>
     <% if (post.link || post.title){ %>
@@ -70,4 +70,8 @@
     <% } %>
     </div>
   </aside>
+<% } else { %>
+    <% if (!index && is_post() && theme.post_sidebar.enable){ %>
+      <%- partial('_partial/sidebar', null, {cache: !config.relative_link}) %>
+    <% } %>
 <% } %>

--- a/layout/_partial/post/date.ejs
+++ b/layout/_partial/post/date.ejs
@@ -1,5 +1,5 @@
 <% if (!is_current("about", false)){ %>
-	Posted on <a href="<%- url_for(post.path) %>" class="<%= class_name %>">
+	<%= __('posted_on') %> <a href="<%- url_for(post.path) %>" class="<%= class_name %>">
 	  <time datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><%= date(post.date, 'MMMM D, YYYY') %></time>
 	</a>
 <% } %>


### PR DESCRIPTION
adding `posted_on` according to language
> file edited ( `date.ejs` )

Updated languages
* en
* es
---
> based on the issue # 39

Editing `_config.yml`

```
# Sidebar like in homepage, is necessary to disable [post_catalog]
  post_sidebar:
    enable: true
```

Example with **post_sidebar** `enable`: 

![alt text](https://preview.ibb.co/bHbikT/Screen_Shot_2018_06_24_at_12_34_57_PM.png "Example with sidebar")