### PR TITLE
[Fix #44] 修复当主题配置文件中没有设置 `google_adsense_ad_client_id` 时崩溃的问题

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -84,6 +84,7 @@
   <!-- Custom CSS -->
   <%- css('css/my.css') %>
   <!-- Google Adsense -->
+  <% if (theme.ad){ %>
   <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
   <script>
       (adsbygoogle = window.adsbygoogle || []).push({
@@ -91,4 +92,5 @@
           enable_page_level_ads: true
       });
   </script>
+  <% } %>
 </head>


### PR DESCRIPTION
[Fix #44]

忘存Log了，对不起。